### PR TITLE
feat: initialEntry is now provided by APIGW endpoint

### DIFF
--- a/src/handlers/createTimeline.ts
+++ b/src/handlers/createTimeline.ts
@@ -5,7 +5,6 @@ import { generateSchnorrKeyPair, createHashFromJson, sign } from '../lib/utils/c
 import TimelineInitialMessage from '../lib/timeline/TimelineInitialMessage.js';
 import { InitialTimelineEntry } from '../lib/timeline';
 import { TimelineRepository } from 'lib/timeline/TimelineRepository.js';
-import YAML from 'yaml'
 
 const repository = new TimelineRepository(process.env.TIMELINE_ENTRIES_TABLE);
 
@@ -54,8 +53,7 @@ const createTimeline = async (event, context) => {
 
     const responseData = {
         TimelineId: timelineId,
-        InitialEntryJson: JSON.stringify(initialEntry),
-        InitialEntryYaml: YAML.stringify(initialEntry),
+        InitialEntry: JSON.stringify(initialEntry),
     };
 
     logger.debug({
@@ -69,8 +67,7 @@ const createTimeline = async (event, context) => {
             Name: process.env.KEYS_SSM_PARAMETER,
             Description: "Timeline Provider Keys",
             Value: JSON.stringify({
-                TimelineId: timelineId,
-                InitialEntry: JSON.stringify(initialEntry),
+                ...responseData,
                 PrivateKey: privateSKey,
             }),
             Type: 'SecureString',

--- a/src/handlers/initialEntryProvider.ts
+++ b/src/handlers/initialEntryProvider.ts
@@ -1,0 +1,28 @@
+import { Logger } from '@aws-lambda-powertools/logger';
+import YAML from 'yaml';
+
+const logger = new Logger();
+
+export const lambdaHandler = async (event) => {
+    logger.debug({
+        message: 'Received event',
+        event,
+    });
+
+    const acceptHeader = event.headers['Accept'] || event.headers['accept'];
+
+    if (acceptHeader === 'application/yaml') {
+        return {
+            statusCode: 200,
+            headers: {'Content-Type': 'application/yaml'},
+            body: YAML.stringify(JSON.parse(process.env.InitialEntry!))
+        };
+    } else {
+        // Default to JSON if the header is not set to YAML
+        return {
+            statusCode: 200,
+            headers: {'Content-Type': 'application/json'},
+            body: process.env.InitialEntry,
+        };
+    }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -169,6 +169,38 @@ Resources:
                   default:
                     statusCode: "200"
 
+          "/initialEntry":
+            post:
+              summary: Provides Timeline initialEntry in JSON or YAML format
+              produces:
+                - "application/json"
+                - "application/yaml"
+              responses:
+                "200":
+                  description: "200 response"
+                  schema:
+                    type: object
+              x-amazon-apigateway-integration:
+                httpMethod: POST
+                type: aws_proxy
+                uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${InitialEntryProviderFunction.Arn}/invocations"
+                credentials: !GetAtt ApiGatewayExecutionRole.Arn
+                passthroughBehavior: when_no_templates
+                responses:
+                  default:
+                    statusCode: "200"
+              security:
+                - api_key: []
+
+  InitialEntryProviderFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: dist/initialEntryProvider
+      Handler: index.lambdaHandler
+      Environment:
+        Variables:
+          InitialEntry: !GetAtt ProviderTimelineGenerator.InitialEntry
+
   ApiGatewayExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -189,7 +221,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - lambda:InvokeFunction
-                Resource: !GetAtt TimelineAddEntry.Arn
+                Resource:
+                 - !GetAtt TimelineAddEntry.Arn
+                 - !GetAtt InitialEntryProviderFunction.Arn
 
   ### Create Timeline Entry Lambda ###
   TimelineAddEntry:
@@ -305,7 +339,7 @@ Resources:
     Properties:
       ServiceToken: !FindInMap [Config, TimelineBlue, RegistrationSNS]
       TimelineId: !GetAtt ProviderTimelineGenerator.TimelineId
-      InitialEntry: !GetAtt ProviderTimelineGenerator.InitialEntryJson
+      InitialEntry: !GetAtt ProviderTimelineGenerator.InitialEntry
 
 Outputs:
   ApiEndpoint:
@@ -317,9 +351,3 @@ Outputs:
   TimelineId:
     Description: ID of the timeline
     Value: !GetAtt ProviderTimelineGenerator.TimelineId
-  InitialEntryJson:
-    Description: Timeline's initial entry, including signature, message, etc
-    Value: !GetAtt ProviderTimelineGenerator.InitialEntryJson
-  InitialEntryYaml:
-    Description: Timeline's initial entry in YAML format
-    Value: !GetAtt ProviderTimelineGenerator.InitialEntryYaml


### PR DESCRIPTION
The endpoint is `/initialEntry`, and it uses `Accept` header to recognize what output is expected, YAML or JSON. JSON is the default, and to get YAML `Accept: application/yaml` should be used:

```
$ curl -XPOST -H 'Accept: application/yaml' -H "x-api-key:M***" https://***/v1/initialEntry
id: d5f4382dd174893d84425b2303054946eb5b02896c7a30f583ebeb6ddcf69f58
timeline: d5f4382dd174893d84425b2303054946eb5b02896c7a30f583ebeb6ddcf69f58
created: 2023-11-29T12:50:35.441Z
signature: 3045022100fe3ac597cc0bc9***
message:
  type:
    name: AWS Basic Timeline with Secp256k1 Schnorr Signature
    sha256: 5f7f807162fc46ca4733d293cffc60dcbfe8c247bfa33f8a2d9b420bbe1415be
  name: MyTimeline
  sqs: arn:aws:sqs:eu-west-1:763766484361:SimpleBlueTimeline-TimelineEntriesSQS-F37plsohOyAg
  publicKey: 0445be4422d7eb98dbb30***
```
and

```
$ curl -XPOST -H 'Accept: application/json' -H "x-api-key:Mk9JhsiaZL27bBpqfp6cL48ugRBppYkm7b7E9m4S" https://x6hhoh37lc.execute-api.eu-west-1.amazonaws.com/v1/initialEntry
{"id":"d5f4382dd174893d84425b2303054946eb5b02896c7a30f583ebeb6ddcf69f58","timeline":"d5f4382dd174893d84425b2303054946eb5b02896c7a30f583ebeb6ddcf69f58","created":"2023-11-29T12:50:35.441Z","signature":"3045022100fe3ac597cc***","message":{"type":{"name":"AWS Basic Timeline with Secp256k1 Schnorr Signature","sha256":"5f7f807162fc46ca4733d293cffc60dcbfe8c247bfa33f8a2d9b420bbe1415be"},"name":"MyTimeline","sqs":"arn:aws:sqs:eu-west-1:763766484361:SimpleBlueTimeline-TimelineEntriesSQS-F37plsohOyAg","publicKey":"0445***
```